### PR TITLE
Added helpful message for wrong arguments count

### DIFF
--- a/main.c
+++ b/main.c
@@ -68,6 +68,11 @@ int main(int argc, char **argv) {
     int bytes = 0;
     int running = 1;
 
+    if(argc != 3) {
+        fprintf(stderr, "Usage: %s <server ip> <server port>\n", argv[0]);
+        return 1;
+    }
+
     if (!initSocket(&socketDesc, argv[1], argv[2])) {
         fprintf(stderr, "Failed in initializing socket\n");
         return 1;


### PR DESCRIPTION
On wrong argument count, the program exits with a Segmentation Fault error. This commit adds a helpful error message to inform the user about usage of the program.
